### PR TITLE
Allow overriding of move base & amcl param files

### DIFF
--- a/fetch_navigation/launch/fetch_nav.launch
+++ b/fetch_navigation/launch/fetch_nav.launch
@@ -7,6 +7,10 @@
   <arg name="map_keepout_file" default="$(find fetch_navigation)/maps/4_26_15_keepout.yaml" />
   <arg name="use_keepout" default="false" />
 
+  <!-- Navigation parameter files -->
+  <arg name="move_base_include" default="$(find fetch_navigation)/launch/include/move_base.launch.xml" />
+  <arg name="amcl_include" default="$(find fetch_navigation)/launch/include/amcl.launch.xml" />
+
   <!-- serve up a map -->
   <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
 
@@ -19,10 +23,10 @@
   </group>
 
   <!-- localize the robot -->
-  <include file="$(find fetch_navigation)/launch/include/amcl.launch.xml" />
+  <include file="$(arg amcl_include)" />
 
   <!-- move the robot -->
-  <include file="$(find fetch_navigation)/launch/include/move_base.launch.xml" >
+  <include file="$(arg move_base_include)" >
     <arg name="name" value="fetch" />
     <arg if="$(arg use_keepout)" name="map_topic" value="map_keepout" />
   </include>

--- a/fetch_navigation/launch/freight_nav.launch
+++ b/fetch_navigation/launch/freight_nav.launch
@@ -7,6 +7,10 @@
   <arg name="map_keepout_file" default="$(find fetch_navigation)/maps/4_26_15_keepout.yaml" />
   <arg name="use_keepout" default="false" />
 
+  <!-- Navigation parameter files -->
+  <arg name="move_base_include" default="$(find fetch_navigation)/launch/include/move_base.launch.xml" />
+  <arg name="amcl_include" default="$(find fetch_navigation)/launch/include/amcl.launch.xml" />
+
   <!-- serve up a map -->
   <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
 
@@ -19,10 +23,10 @@
   </group>
 
   <!-- localize the robot -->
-  <include file="$(find fetch_navigation)/launch/include/amcl.launch.xml" />
+  <include file="$(arg amcl_include)" />
 
   <!-- move the robot -->
-  <include file="$(find fetch_navigation)/launch/include/move_base.launch.xml" >
+  <include file="$(arg move_base_include)" >
     <arg name="name" value="freight" />
     <arg if="$(arg use_keepout)" name="map_topic" value="map_keepout" />
   </include>


### PR DESCRIPTION
This makes it easy to override move_base and amcl parameters in your package while still using the default fetch & freight nav launch files
