### PR TITLE
Tucking now stops if the deadman is released

### DIFF
--- a/fetch_teleop/scripts/tuck_arm.py
+++ b/fetch_teleop/scripts/tuck_arm.py
@@ -30,6 +30,7 @@
 
 import argparse
 import subprocess
+import sys
 from threading import Thread
 
 import rospy
@@ -59,39 +60,63 @@ def is_moveit_running():
         return False
     return True
 
-def tuck():
-    move_thread = None
-    if not is_moveit_running():
-        rospy.loginfo("starting moveit")
-        move_thread = MoveItThread()
+class TuckThread(Thread):
 
-    rospy.loginfo("Waiting for MoveIt...")
-    client = MoveGroupInterface("arm_with_torso", "base_link")
-    rospy.loginfo("...connected")
+    def __init__(self):
+        Thread.__init__(self)
+        self.client = None
+        self.start()
 
-    # Padding does not work (especially for self collisions)
-    # So we are adding a box above the base of the robot
-    scene = PlanningSceneInterface("base_link")
-    scene.addBox("keepout", 0.2, 0.5, 0.05, 0.15, 0.0, 0.375)
+    def run(self):
+        move_thread = None
+        if not is_moveit_running():
+            rospy.loginfo("starting moveit")
+            move_thread = MoveItThread()
 
-    joints = ["torso_lift_joint", "shoulder_pan_joint", "shoulder_lift_joint", "upperarm_roll_joint",
-              "elbow_flex_joint", "forearm_roll_joint", "wrist_flex_joint", "wrist_roll_joint"]
-    pose = [0.05, 1.32, 1.40, -0.2, 1.72, 0.0, 1.66, 0.0]
-    while not rospy.is_shutdown():
-        result = client.moveToJointPosition(joints,
-                                            pose,
-                                            0.0,
-                                            max_velocity_scaling_factor=0.5)
-        if result.error_code.val == MoveItErrorCodes.SUCCESS:
-            scene.removeCollisionObject("keepout")
-            if move_thread:
-                move_thread.stop()
-            return
+        rospy.loginfo("Waiting for MoveIt...")
+        self.client = MoveGroupInterface("arm_with_torso", "base_link")
+        rospy.loginfo("...connected")
+
+        # Padding does not work (especially for self collisions)
+        # So we are adding a box above the base of the robot
+        scene = PlanningSceneInterface("base_link")
+        scene.addBox("keepout", 0.2, 0.5, 0.05, 0.15, 0.0, 0.375)
+
+        joints = ["torso_lift_joint", "shoulder_pan_joint", "shoulder_lift_joint", "upperarm_roll_joint",
+                  "elbow_flex_joint", "forearm_roll_joint", "wrist_flex_joint", "wrist_roll_joint"]
+        pose = [0.05, 1.32, 1.40, -0.2, 1.72, 0.0, 1.66, 0.0]
+        while not rospy.is_shutdown():
+            result = self.client.moveToJointPosition(joints,
+                                                     pose,
+                                                     0.0,
+                                                     max_velocity_scaling_factor=0.5)
+            if result.error_code.val == MoveItErrorCodes.SUCCESS:
+                scene.removeCollisionObject("keepout")
+                if move_thread:
+                    move_thread.stop()
+
+                # On success quit
+                # Stopping the MoveIt thread works, however, the action client
+                # does not get shut down, and future tucks will not work.
+                # As a work-around, we die and roslaunch will respawn us.
+                rospy.signal_shutdown("done")
+                sys.exit(0)
+                return
+
+    def stop(self):
+        if self.client:
+            self.client.get_move_action().cancel_goal()
+        # Stopping the MoveIt thread works, however, the action client
+        # does not get shut down, and future tucks will not work.
+        # As a work-around, we die and roslaunch will respawn us.
+        rospy.signal_shutdown("failed")
+        sys.exit(0)
 
 class TuckArmTeleop:
 
     def __init__(self):
         self.tuck_button = rospy.get_param("~tuck_button", 6)  # default button is the down button
+        self.deadman = rospy.get_param("~deadman_button", 10)
         self.tucking = False
 
         self.pressed = False
@@ -101,22 +126,22 @@ class TuckArmTeleop:
 
     def joy_callback(self, msg):
         if self.tucking:
-            # only run once
+            # Only run once
+            if msg.buttons[self.deadman] <= 0:
+                # Deadman has been released, don't tuck
+                rospy.loginfo("Stopping tuck thread")
+                self.tuck_thread.stop()
             return
         try:
-            if msg.buttons[self.tuck_button] > 0:
+            if msg.buttons[self.tuck_button] > 0 and msg.buttons[self.deadman] > 0:
                 if not self.pressed:
                     self.pressed_last = rospy.Time.now()
                     self.pressed = True
                 elif self.pressed_last and rospy.Time.now() > self.pressed_last + rospy.Duration(1.0):
                     # Tuck the arm
                     self.tucking = True
-                    tuck()
-                    # Stopping the MoveIt thread works, however, the action client
-                    # does not get shut down, and future tucks will not work.
-                    # As a work-around, we die and roslaunch will respawn us.
-                    rospy.signal_shutdown("done")
-                    exit(0)
+                    rospy.loginfo("Starting tuck thread")
+                    self.tuck_thread = TuckThread()
             else:
                 self.pressed = False
         except KeyError:
@@ -128,10 +153,11 @@ if __name__ == "__main__":
     args, unknown = parser.parse_known_args()
 
     rospy.init_node("tuck_arm")
+    rospy.loginfo("New tuck script running")
 
     if args.joystick:
         t = TuckArmTeleop()
         rospy.spin()
     else:
         rospy.loginfo("Tucking the arm")
-        tuck()
+        TuckThread()


### PR DESCRIPTION
This updates the tucking script to stop when the deadman is released. This is now consistent with how the rest of teleop works and allows the user to stop the tucking if a collision is occuring.
