### PR TITLE
Update move_base.yaml

### DIFF
--- a/fetch_navigation/config/fetch/move_base.yaml
+++ b/fetch_navigation/config/fetch/move_base.yaml
@@ -17,11 +17,11 @@ recovery_behavior_enabled: true
 recovery_behaviors:
   - name: "conservative_reset"
     type: "clear_costmap_recovery/ClearCostmapRecovery"
-    reset_distance: 3.0
   - name: "rotate_recovery"
     type: "rotate_recovery/RotateRecovery"
     frequency: 20.0
     sim_granularity: 0.017
   - name: "aggressive_reset"
     type: "clear_costmap_recovery/ClearCostmapRecovery"
-    reset_distance: 0.5
+conservative_reset: {reset_distance: 3.0}
+aggressive_reset: {reset_distance: 0.5}


### PR DESCRIPTION
since https://github.com/ros-planning/navigation/blob/jade-devel/clear_costmap_recovery/src/clear_costmap_recovery.cpp#L61 reads param from private **namespace + name**, we need to use plugin name as namespace to the reset_distance names
