### PR TITLE
run_depends on package, not meta-package

### DIFF
--- a/fetch_navigation/CMakeLists.txt
+++ b/fetch_navigation/CMakeLists.txt
@@ -18,3 +18,9 @@ install(
   PROGRAMS scripts/tilt_head.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS roslaunch)
+  roslaunch_add_file_check(launch/fetch_nav.launch)
+  roslaunch_add_file_check(launch/freight_nav.launch)
+endif()

--- a/fetch_navigation/package.xml
+++ b/fetch_navigation/package.xml
@@ -9,7 +9,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>fetch_depth_layer</run_depend>
-  <run_depend>navigation</run_depend>
+  <run_depend>map_server</run_depend>
+  <run_depend>amcl</run_depend>
+  <run_depend>move_base</run_depend>
   <run_depend>fetch_maps</run_depend>
   <run_depend>slam_karto</run_depend>
 </package>


### PR DESCRIPTION
as denoted in http://www.ros.org/reps/rep-0127.html#metapackage

```
Catkin packages must depend directly on the packages they use, not on any metapackages.
```

This may cause problems when we try to test launch file using `roslaunch_add_file_check`
- add roslaunch_add_file_check tests
- run_depends on package, not meta-package
