### PR TITLE
Fixes an issue that tuck_arm.py spawns new roscore.

### DIFF
--- a/fetch_teleop/scripts/tuck_arm.py
+++ b/fetch_teleop/scripts/tuck_arm.py
@@ -14,7 +14,7 @@
 #     * Neither the name of the Fetch Robotics Inc. nor the names of its
 #       contributors may be used to endorse or promote products derived from
 #       this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -45,7 +45,7 @@ class MoveItThread(Thread):
         self.start()
 
     def run(self):
-        self.process = subprocess.Popen(["roslaunch", "fetch_moveit_config", "move_group.launch"])
+        self.process = subprocess.Popen(["roslaunch", "fetch_moveit_config", "move_group.launch", "--wait"])
         _, _ = self.process.communicate()
 
     def stop(self):


### PR DESCRIPTION
tuck_arm.py calls roslaunch without --wait flag, which may spawn new ROS
master in a racing condition.