### PR TITLE
remove up_axis tag from DAE meshes

### DIFF
--- a/fetch_description/meshes/elbow_flex_link.dae
+++ b/fetch_description/meshes/elbow_flex_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-29T22:54:40</created>
     <modified>2015-01-29T22:54:40</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="elbow_flex_uv" name="elbow_flex_uv">

--- a/fetch_description/meshes/forearm_roll_link.dae
+++ b/fetch_description/meshes/forearm_roll_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-31T11:27:56</created>
     <modified>2015-01-31T11:27:56</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="forearm_roll_uv" name="forearm_roll_uv">

--- a/fetch_description/meshes/gripper_link.dae
+++ b/fetch_description/meshes/gripper_link.dae
@@ -8,7 +8,6 @@
     <created>2015-10-11T03:38:44</created>
     <modified>2015-10-11T03:38:44</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_cameras>
     <camera id="Camera-camera" name="Camera">

--- a/fetch_description/meshes/head_pan_link.dae
+++ b/fetch_description/meshes/head_pan_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-31T13:35:38</created>
     <modified>2015-01-31T13:35:38</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="head_pan_uv" name="head_pan_uv">

--- a/fetch_description/meshes/head_tilt_link.dae
+++ b/fetch_description/meshes/head_tilt_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-31T13:29:03</created>
     <modified>2015-01-31T13:29:03</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="head_tilt_uv" name="head_tilt_uv">

--- a/fetch_description/meshes/shoulder_lift_link.dae
+++ b/fetch_description/meshes/shoulder_lift_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-30T23:57:00</created>
     <modified>2015-01-30T23:57:00</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="shoulder_lift_uv" name="shoulder_lift_uv">

--- a/fetch_description/meshes/shoulder_pan_link.dae
+++ b/fetch_description/meshes/shoulder_pan_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-31T13:57:18</created>
     <modified>2015-01-31T13:57:18</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="shoulder_pan_uv" name="shoulder_pan_uv">

--- a/fetch_description/meshes/torso_fixed_link.dae
+++ b/fetch_description/meshes/torso_fixed_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-31T15:49:27</created>
     <modified>2015-01-31T15:49:27</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="torso_fixed_uv" name="torso_fixed_uv">

--- a/fetch_description/meshes/torso_lift_link.dae
+++ b/fetch_description/meshes/torso_lift_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-31T10:53:49</created>
     <modified>2015-01-31T10:53:49</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="torso_lift_uv" name="torso_lift_uv">

--- a/fetch_description/meshes/upperarm_roll_link.dae
+++ b/fetch_description/meshes/upperarm_roll_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-31T14:13:51</created>
     <modified>2015-01-31T14:13:51</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="upperarm_roll_uv" name="upperarm_roll_uv">

--- a/fetch_description/meshes/wrist_flex_link.dae
+++ b/fetch_description/meshes/wrist_flex_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-31T11:01:45</created>
     <modified>2015-01-31T11:01:45</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="wrist_flex_uv" name="wrist_flex_uv">

--- a/fetch_description/meshes/wrist_roll_link.dae
+++ b/fetch_description/meshes/wrist_roll_link.dae
@@ -8,7 +8,6 @@
     <created>2015-01-31T15:36:44</created>
     <modified>2015-01-31T15:36:44</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_images>
     <image id="wrist_roll_uv" name="wrist_roll_uv">


### PR DESCRIPTION
RViz doesn't respect it anyway ( https://github.com/ros-visualization/rviz/issues/1045 ), but current versions of three.js' ColladaLoader (used in the RobotWebTools, see https://github.com/RobotWebTools/ros3djs/pull/202 ) do!

(Since RViz doesn't respect the tag, this does not break the model)