### PR TITLE
Localized position of fetch often jumps

### DIFF
--- a/fetch_navigation/config/amcl.yaml
+++ b/fetch_navigation/config/amcl.yaml
@@ -27,11 +27,11 @@ laser_z_rand: 0.05
 laser_sigma_hit: 0.2
 
 # Odometry model
-odom_model_type: "diff"
-odom_alpha1: 1.5  # rotation noise per rotation
+odom_model_type: "diff-corrected"
+odom_alpha1: 0.15  # rotation noise per rotation
 odom_alpha2: 0.5  # rotation noise per translation
 odom_alpha3: 0.5  # translation noise per translation
-odom_alpha4: 1.5  # translation noise per rotation
+odom_alpha4: 0.15  # translation noise per rotation
 odom_frame_id: "odom"
 base_frame_id: "base_link"
 global_frame_id: "map"


### PR DESCRIPTION
When I navigate `fetch` with default parameters of `amcl`, `fetch` in `Rviz` often jumps.
To solve this problem, I changed the params (like http://wiki.ros.org/amcl and https://answers.ros.org/question/227811/tuning-amcls-diff-corrected-and-omni-corrected-odom-models/)
and did an experiment in which I turned `fetch` on the spot by teleop.

When I use the default params, `fetch` in `Rviz` moves away (See video below).
On the other hand, when I use the params with this Pull Request, `fetch` in `Rviz` does not translate. (It only rotates)

Overview of these scene is like below:
### :x: with default params (`fetch` not only rotates but also translates)
![navigation_params_now_trim_cp](https://user-images.githubusercontent.com/19769486/41770382-fd6ea5aa-764c-11e8-9d10-655d3f0dd711.gif)

### :o: with new params(`fetch` only rotates)
![navigation_params_new_trim_cp](https://user-images.githubusercontent.com/19769486/41770388-019da0d6-764d-11e8-96d7-a0d55cf05782.gif)

I attached rosbag files.
https://drive.google.com/open?id=1dU5yOxgr7li6psC43kXn63GTkp_0O21O

You can reproduce the scene from the attached zip file. You need to type commands below:
```
unzip fetch_navigation.zip
cd fetch_navigation/
roslaunch play_navigation.launch filename:=$(pwd)/navigation_now.bag
rviz -d $(pwd)/fetch_navigation.rviz
```
