### PR TITLE
Update fetch.urdf to remove KDL warning using gazebo-7

### DIFF
--- a/fetch_description/robots/fetch.urdf
+++ b/fetch_description/robots/fetch.urdf
@@ -1,4 +1,18 @@
 <robot name="fetch">
+  <!-- Added here so gazebo doesnt complain. Removing this gives warning:
+  The root link base_link has an inertia specified in the URDF, but KDL does not support a root link with an inertia.
+  As a workaround, you can add an extra dummy link to your URDF.
+
+  Since the root cannot have inertia in KDL, we make a dummy_link to act as the root.-->
+  <joint name="dummy_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0" />
+    <parent link="dummy_link" />
+    <child link="base_link" />
+  </joint>
+  <link name="dummy_link">
+    <origin rpy="0 0 0" xyz="0 0 0" />
+  </link>
+  
   <link name="base_link">
     <inertial>
       <origin rpy="0 0 0" xyz="-0.0036 0.0 0.0014" />


### PR DESCRIPTION
For Gazebo-7, a warning comes up saying:
  The root link base_link has an inertia specified in the URDF, but KDL does not support a root link with an inertia.
  As a workaround, you can add an extra dummy link to your URDF.

Here is a link to the solution: https://answers.ros.org/question/192817/error-msg-the-root-link_base-has-an-inertia-specified-in-the-urdf-but-kdl/

Of course, maybe there is a better way to do this without adding a dummy, and it would be important to verify that this still works in older versions of gazebo.