### PR TITLE
[Depth Layer] Fixes OpenCV3 symbol lookup error

### DIFF
--- a/fetch_depth_layer/CMakeLists.txt
+++ b/fetch_depth_layer/CMakeLists.txt
@@ -12,17 +12,35 @@ find_package(catkin REQUIRED
     nav_msgs
 )
 
-catkin_package()
+find_package(OpenCV 3.2 REQUIRED)
+
+catkin_package(
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    fech_depth_layer
+  CATKIN_DEPENDS
+    image_transport
+    cv_bridge
+    roscpp
+    sensor_msgs
+    costmap_2d
+    nav_msgs
+  DEPENDS
+    OpenCV
+)
 
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
 )
 
 add_library(fetch_depth_layer src/depth_layer.cpp)
 
 target_link_libraries(fetch_depth_layer
   ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 
 install(FILES costmap_plugins.xml


### PR DESCRIPTION
Regression from #78 
When Testing move_base on Melodic, had the following error:

/opt/ros/melodic-stable/lib/move_base/move_base:
  symbol lookup error:
  /opt/ros/melodic-stable/lib/libfetch_depth_layer.so:
  undefined symbol:
  _ZN2cv4rgbd9depthTo3dERKNS_11_InputArrayES3_RKNS_12_OutputArrayES3_

[move_base-3] process has died [pid 16834, exit code 127, ...]

Originally when I did the build last week I didn't yet have #78 merged, and still depended on opencv_candidate which found the OpenCV libs for us.