### PR TITLE
[fetch_depth_layer][tf2] ros-planning/navigation#755

### DIFF
--- a/fetch_calibration/config/calibrate.yaml
+++ b/fetch_calibration/config/calibrate.yaml
@@ -47,9 +47,9 @@ free_frames:
    yaw: false
 error_blocks:
  - name: hand_eye
-   type: camera3d_to_arm
-   camera: camera
-   arm: arm
+   type: chain3d_to_chain3d
+   model_a: camera
+   model_b: arm
  - name: restrict_camera
    type: outrageous
    param: head_camera_rgb_joint

--- a/fetch_calibration/config/calibrate_with_ground.yaml
+++ b/fetch_calibration/config/calibrate_with_ground.yaml
@@ -47,13 +47,17 @@ free_frames:
    yaw: false
 error_blocks:
  - name: hand_eye
-   type: camera3d_to_arm
-   camera: camera
-   arm: arm
+   type: chain3d_to_chain3d
+   model_a: camera
+   model_b: arm
  - name: ground_plane
-   type: camera3d_to_ground
-   camera: camera
-   ground: ground
+   type: chain3d_to_plane
+   model_a: camera
+   a: 0.0
+   b: 0.0
+   c: 1.0
+   d: 0.0
+   scale: 1.0
  - name: restrict_camera
    type: outrageous
    param: head_camera_rgb_joint

--- a/fetch_calibration/config/capture_with_ground.yaml
+++ b/fetch_calibration/config/capture_with_ground.yaml
@@ -50,8 +50,9 @@ features:
         y: -0.0355
         z: 0.0396
   ground_plane_finder:
-    type: robot_calibration/GroundPlaneFinder
+    type: robot_calibration/PlaneFinder
     topic: /head_camera/depth_registered/points
     camera_sensor_name: camera
-    chain_sensor_name: ground
-    ground_frame: base_link
+    transform_frame: base_link
+    min_z: -2.0
+    max_z: 2.0

--- a/fetch_depth_layer/CMakeLists.txt
+++ b/fetch_depth_layer/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(catkin REQUIRED
     image_transport
     cv_bridge
     sensor_msgs
+    geometry_msgs
+    tf2_ros
     costmap_2d
     nav_msgs
 )
@@ -24,6 +26,8 @@ catkin_package(
     cv_bridge
     roscpp
     sensor_msgs
+    tf2_ros
+    geometry_msgs
     costmap_2d
     nav_msgs
   DEPENDS

--- a/fetch_depth_layer/include/fetch_depth_layer/depth_layer.h
+++ b/fetch_depth_layer/include/fetch_depth_layer/depth_layer.h
@@ -37,7 +37,7 @@
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
-#include <tf/message_filter.h>
+#include <tf2_ros/message_filter.h>
 #include <message_filters/subscriber.h>
 
 #include <opencv2/rgbd.hpp>
@@ -109,7 +109,7 @@ private:
   // retrieves depth image from head_camera
   // used to fit ground plane to
   boost::shared_ptr< message_filters::Subscriber<sensor_msgs::Image> > depth_image_sub_;
-  boost::shared_ptr< tf::MessageFilter<sensor_msgs::Image> > depth_image_filter_;
+  boost::shared_ptr< tf2_ros::MessageFilter<sensor_msgs::Image> > depth_image_filter_;
 
   // retrieves camera matrix for head_camera
   // used in calculating ground plane

--- a/fetch_depth_layer/package.xml
+++ b/fetch_depth_layer/package.xml
@@ -19,6 +19,8 @@
   <build_depend>image_transport</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
 
   <run_depend>pluginlib</run_depend>
   <run_depend>roscpp</run_depend>
@@ -27,6 +29,8 @@
   <run_depend>image_transport</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>tf2_ros</run_depend>
 
   <export>
     <costmap_2d plugin="${prefix}/costmap_plugins.xml" />


### PR DESCRIPTION
Don't merge this until ros-planning/navigation#755 is accepted.
See also: https://github.com/ros-planning/navigation/issues/749#issuecomment-405812657

Updates fetch_depth_layer for tf2 changes coming upstream.
Navigation on melodic isn't released yet: https://github.com/ros-planning/navigation/milestone/4 but will hopefully include the switch to **tf2** :tada: 

Relates to: https://github.com/fetchrobotics/fetch_ros/issues/63