### PR TITLE
[fetch_depth_layer] Fix normals_estimator_ no match for ‘operator=’ error

### DIFF
--- a/fetch_depth_layer/src/depth_layer.cpp
+++ b/fetch_depth_layer/src/depth_layer.cpp
@@ -232,10 +232,11 @@ void FetchDepthLayer::depthImageCallback(
     // Get normals
     if (normals_estimator_.empty())
     {
-      normals_estimator_ = new RgbdNormals(cv_ptr->image.rows,
-                                           cv_ptr->image.cols,
-                                           cv_ptr->image.depth(),
-                                           K_);
+      normals_estimator_.reset(new RgbdNormals());
+      normals_estimator_->setRows(cv_ptr->image.rows);
+      normals_estimator_->setCols(cv_ptr->image.cols);
+      normals_estimator_->setDepth(cv_ptr->image.depth());
+      normals_estimator_->setK(K_);
     }
     cv::Mat normals;
     (*normals_estimator_)(points3d, normals);

--- a/fetch_depth_layer/src/depth_layer.cpp
+++ b/fetch_depth_layer/src/depth_layer.cpp
@@ -232,11 +232,10 @@ void FetchDepthLayer::depthImageCallback(
     // Get normals
     if (normals_estimator_.empty())
     {
-      normals_estimator_.reset(new RgbdNormals());
-      normals_estimator_->setRows(cv_ptr->image.rows);
-      normals_estimator_->setCols(cv_ptr->image.cols);
-      normals_estimator_->setDepth(cv_ptr->image.depth());
-      normals_estimator_->setK(K_);
+      normals_estimator_.reset(new RgbdNormals(cv_ptr->image.rows,
+                                               cv_ptr->image.cols,  
+                                               cv_ptr->image.depth(),
+                                               K_));
     }
     cv::Mat normals;
     (*normals_estimator_)(points3d, normals);


### PR DESCRIPTION
Fix how `normals_estimator_ cv::Ptr` was being set.

Set the `normals_estimator_` using `.reset()` method instead of `operator=`. 

- The [opencv 4.0.0 reset()](https://docs.opencv.org/master/d0/de7/structcv_1_1Ptr.html#a8100350b806a4e664cbec3445b8d30a0) expects a `Y *` which is what the `new `keyword will be returning. 
- The [opencv 4.0.0 operator=](https://docs.opencv.org/master/d0/de7/structcv_1_1Ptr.html#a468377d212f11a2501dcb3fab37955cd) expects a `const cv:Ptr<T> &` which is not what the `new` keyword is returning.

The result is changing:
- normals_estimator_ = new RgbdNormals( ...
To:
- normals_estimator_.reset(new RgbdNormals( ...

Note, as of 7/22/2018 #81 has been referenced to get this to work, and modified the files specified in that issue along with my one commit.

Extra Contextual Info:
This commit fits closer to how smart pointers are supposed to be used in Boost C++11 libraries. The [opencv Ptr](https://docs.opencv.org/3.4/d0/de7/structcv_1_1Ptr.html#details) is similar to [boost::shared_ptr](https://theboostcpplibraries.com/boost.smartpointers-shared-ownership). Using `reset()` for pointing a smart pointer to a new instance seems to be the "more" correct way to use these pointers. Using the `operator=` seems unusual. 

The error below would occur without this commit:
```
~$ pkg-config --modversion opencv
4.0.0
~/PycharmProjects/fetch_robot_ws$ catkin_make
-- The C compiler identification is GNU 7.3.0
-- The CXX compiler identification is GNU 7.3.0
-- Boost version: 1.65.1
...
[ 97%] Building CXX object navigation/move_base/CMakeFiles/move_base.dir/src/move_base.cpp.o
/home/josiah/PycharmProjects/fetch_robot_ws/src/fetch_ros/fetch_depth_layer/src/depth_layer.cpp: In member function ‘void costmap_2d::FetchDepthLayer::depthImageCallback(const ConstPtr&)’:
/home/josiah/PycharmProjects/fetch_robot_ws/src/fetch_ros/fetch_depth_layer/src/depth_layer.cpp:239:28: error: no match for ‘operator=’ (operand types are ‘cv::Ptr<cv::rgbd::RgbdNormals>’ and ‘cv::rgbd::RgbdNormals*’)
       normals_estimator_ = new RgbdNormals(cv_ptr->image.rows,cv_ptr->image.cols,  cv_ptr->image.depth(),K_);
                            ^~~~
In file included from /usr/local/include/opencv2/core/cvstd.hpp:1033:0,
                 from /usr/local/include/opencv2/core/base.hpp:58,
                 from /usr/local/include/opencv2/core.hpp:54,
                 from /usr/local/include/opencv2/core/core.hpp:48,
                 from /opt/ros/melodic/include/cv_bridge/cv_bridge.h:43,
                 from /home/josiah/PycharmProjects/fetch_robot_ws/src/fetch_ros/fetch_depth_layer/include/fetch_depth_layer/depth_layer.h:37,
                 from /home/josiah/PycharmProjects/fetch_robot_ws/src/fetch_ros/fetch_depth_layer/src/depth_layer.cpp:32:
/usr/local/include/opencv2/core/ptr.inl.hpp:160:9: note: candidate: cv::Ptr<T>& cv::Ptr<T>::operator=(const cv::Ptr<T>&) [with T = cv::rgbd::RgbdNormals]
 Ptr<T>& Ptr<T>::operator = (const Ptr<T>& o)
         ^~~~~~
```
