### PR TITLE
Add arg use_map_topic to fetch_nav.launch

### DIFF
--- a/fetch_navigation/launch/fetch_nav.launch
+++ b/fetch_navigation/launch/fetch_nav.launch
@@ -6,6 +6,7 @@
   <arg name="map_file" default="$(find fetch_maps)/maps/3_1_16_localization.yaml" />
   <arg name="map_keepout_file" default="$(find fetch_maps)/maps/3_1_16_keepout.yaml" />
   <arg name="use_keepout" default="false" />
+  <arg name="use_map_topic" default="false" />
 
   <!-- Navigation parameter files -->
   <arg name="move_base_include" default="$(find fetch_navigation)/launch/include/move_base.launch.xml" />
@@ -23,7 +24,9 @@
   </group>
 
   <!-- localize the robot -->
-  <include file="$(arg amcl_include)" />
+  <include file="$(arg amcl_include)" >
+    <arg name="use_map_topic" value="$(arg use_map_topic)" />
+  </include>
 
   <!-- move the robot -->
   <include file="$(arg move_base_include)" >


### PR DESCRIPTION
This Pull Request enables to choose whether fetch robots use `map` topic or not from `fetch_nav.launch`.
I think that many fetch robots use `map` topic, so this `use_map_topic` argument is convenient.