### PR TITLE
[Docs] Add URL tags to package for wiki.ros.org (backport)

### DIFF
--- a/fetch_calibration/package.xml
+++ b/fetch_calibration/package.xml
@@ -11,6 +11,9 @@
 
   <license>Apache2</license>
   <url>http://ros.org/wiki/fetch_calibration</url>
+  <url type="website">http://docs.fetchrobotics.com/calibration.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
   
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/fetch_calibration/package.xml
+++ b/fetch_calibration/package.xml
@@ -10,7 +10,7 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>Apache2</license>
-  <url>http://ros.org/wiki/fetch_calibration</url>
+  <url type="wiki">http://ros.org/wiki/fetch_calibration</url>
   <url type="website">http://docs.fetchrobotics.com/calibration.html</url>
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
   <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>

--- a/fetch_depth_layer/package.xml
+++ b/fetch_depth_layer/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
-  <url>http://ros.org/wiki/fetch_depth_layer</url>
+  <url type="wiki">http://ros.org/wiki/fetch_depth_layer</url>
   <url type="website">http://docs.fetchrobotics.com/perception.html</url>
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
   <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>

--- a/fetch_depth_layer/package.xml
+++ b/fetch_depth_layer/package.xml
@@ -9,6 +9,10 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
+  <url>http://ros.org/wiki/fetch_depth_layer</url>
+  <url type="website">http://docs.fetchrobotics.com/perception.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   

--- a/fetch_description/package.xml
+++ b/fetch_description/package.xml
@@ -11,6 +11,11 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>CreativeCommons-Attribution-NonCommercial-NoDerivatives-4.0</license>
+  <url>http://ros.org/wiki/fetch_description</url>
+  <url type="website">http://docs.fetchrobotics.com/robot_hardware.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
+
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>

--- a/fetch_description/package.xml
+++ b/fetch_description/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>CreativeCommons-Attribution-NonCommercial-NoDerivatives-4.0</license>
-  <url>http://ros.org/wiki/fetch_description</url>
+  <url type="wiki">http://ros.org/wiki/fetch_description</url>
   <url type="website">http://docs.fetchrobotics.com/robot_hardware.html</url>
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
   <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>

--- a/fetch_ikfast_plugin/package.xml
+++ b/fetch_ikfast_plugin/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>Apache2</license>
-  <url>http://ros.org/wiki/fetch_ikfast_plugin</url>
+  <url type="wiki">http://ros.org/wiki/fetch_ikfast_plugin</url>
   <url type="website">http://docs.fetchrobotics.com/manipulation.html</url>
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
   <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>

--- a/fetch_ikfast_plugin/package.xml
+++ b/fetch_ikfast_plugin/package.xml
@@ -11,6 +11,10 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>Apache2</license>
+  <url>http://ros.org/wiki/fetch_ikfast_plugin</url>
+  <url type="website">http://docs.fetchrobotics.com/manipulation.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/fetch_maps/package.xml
+++ b/fetch_maps/package.xml
@@ -5,13 +5,16 @@
   <description>The fetch_maps package</description>
 
   <author>Michael Ferguson</author>
+  <author>Michael Gregg</author>
+  <author>Aaron Blasdel</author>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
-  <author>Michael Gregg</author>
-  <author>Michael Ferguson</author>
-  <author>Aaron Blasdel</author>
   <license>BSD</license>
+  <url>http://ros.org/wiki/fetch_maps</url>
+  <url type="website">http://docs.fetchrobotics.com/navigation.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 </package>

--- a/fetch_maps/package.xml
+++ b/fetch_maps/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
-  <url>http://ros.org/wiki/fetch_maps</url>
+  <url type="wiki">http://ros.org/wiki/fetch_maps</url>
   <url type="website">http://docs.fetchrobotics.com/navigation.html</url>
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
   <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>

--- a/fetch_moveit_config/package.xml
+++ b/fetch_moveit_config/package.xml
@@ -11,6 +11,7 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
+  <url>http://ros.org/wiki/fetch_moveit_config</url>
 
   <url type="website">http://moveit.ros.org/</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit_setup_assistant/issues</url>

--- a/fetch_navigation/package.xml
+++ b/fetch_navigation/package.xml
@@ -8,7 +8,10 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
-  <author>Michael Ferguson</author>
+  <url>http://ros.org/wiki/fetch_navigation</url>
+  <url type="website">http://docs.fetchrobotics.com/navigation.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/fetch_navigation/package.xml
+++ b/fetch_navigation/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
-  <url>http://ros.org/wiki/fetch_navigation</url>
+  <url type="wiki">http://ros.org/wiki/fetch_navigation</url>
   <url type="website">http://docs.fetchrobotics.com/navigation.html</url>
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
   <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>

--- a/fetch_teleop/package.xml
+++ b/fetch_teleop/package.xml
@@ -10,7 +10,7 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
-  <url>http://ros.org/wiki/fetch_teleop</url>
+  <url type="wiki">http://ros.org/wiki/fetch_teleop</url>
   <url type="website">http://docs.fetchrobotics.com/teleop.html</url>
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
   <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>

--- a/fetch_teleop/package.xml
+++ b/fetch_teleop/package.xml
@@ -11,6 +11,9 @@
 
   <license>BSD</license>
   <url>http://ros.org/wiki/fetch_teleop</url>
+  <url type="website">http://docs.fetchrobotics.com/teleop.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
   
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
The <url> tag is required to automatically fill in at least some info
on the wiki pages. The extra tags will create links to our docs.

#90 back-port