### PR TITLE
Fix launch file indigo (back-port #96)

### DIFF
--- a/fetch_calibration/launch/capture_manual.launch
+++ b/fetch_calibration/launch/capture_manual.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <rosparam command="delete" param="robot_calibration" >
+  <rosparam command="delete" param="robot_calibration" />
   <node pkg="robot_calibration" type="calibrate" name="robot_calibration"
         args="--manual"
         output="screen" required="true">


### PR DESCRIPTION
Noticed here https://index.ros.org/stats/errors/

    Failed to parse launchfile launch/capture_manual.launch:
        Missing end tag for 'rosparam' (got "launch")
        Line: 16 Position: 668 Last 80 unconsumed characters:

backport https://github.com/fetchrobotics/fetch_ros/pull/96