### PR TITLE
removed hardcoded ROS distro from calibrate_robot

### DIFF
--- a/fetch_calibration/scripts/calibrate_robot
+++ b/fetch_calibration/scripts/calibrate_robot
@@ -20,6 +20,7 @@
 import argparse
 import os
 import rospkg
+import rospkg.distro
 import subprocess
 import time
 import yaml
@@ -174,7 +175,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     restart = False
-    rosdistro = "indigo"
+    rosdistro = rospkg.distro.current_distro_codename()
     etc_launch = "/etc/ros/%s/robot.launch" % rosdistro
 
     if args.date:


### PR DESCRIPTION
Previously, the `indigo` distro was hard-coded into the `calibrate_robot` script. This change replaces the hard-coded string with the current distro codename through `rospkg.distro`. 
(see: http://docs.ros.org/independent/api/rospkg/html/rospkg_distro.html)

This makes the script compatible with melodic, not to mention any arbitrary distro.