### PR TITLE
[upstream] change pluginlib includes: h -> hpp

### DIFF
--- a/fetch_depth_layer/src/depth_layer.cpp
+++ b/fetch_depth_layer/src/depth_layer.cpp
@@ -28,7 +28,7 @@
 
 // Author: Anuj Pasricha, Michael Ferguson
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <fetch_depth_layer/depth_layer.h>
 #include <limits>
 #include <geometry_msgs/Vector3Stamped.h>


### PR DESCRIPTION
pluginlib provided a script for this change, and it's been back-ported to Indigo, Kinetic- but not Jade.