### PR TITLE
[fetch_depth_layer][OpenCV-4] operator= compile error

### DIFF
--- a/fetch_depth_layer/src/depth_layer.cpp
+++ b/fetch_depth_layer/src/depth_layer.cpp
@@ -233,10 +233,10 @@ void FetchDepthLayer::depthImageCallback(
     // Get normals
     if (normals_estimator_.empty())
     {
-      normals_estimator_ = new RgbdNormals(cv_ptr->image.rows,
-                                           cv_ptr->image.cols,
-                                           cv_ptr->image.depth(),
-                                           K_);
+      normals_estimator_.reset(new RgbdNormals(cv_ptr->image.rows,
+                                               cv_ptr->image.cols,
+                                               cv_ptr->image.depth(),
+                                               K_));
     }
     cv::Mat normals;
     (*normals_estimator_)(points3d, normals);


### PR DESCRIPTION
This fixes no match for ‘operator=’ error with OpenCV4 and how the cv::Ptr was being set.

Fixed by setting the normals_estimator_ pointer similarly to how the plane_estimator_ pointer is being set.

The error below would occur:

    fetch_robot_ws/src/fetch_ros/fetch_depth_layer/src/depth_layer.cpp:239:28:
    error: no match for ‘operator=’ (operand types are ‘cv::Ptr<cv::rgbd::RgbdNormals>’ and ‘cv::rgbd::RgbdNormals*’)
           normals_estimator_ = new RgbdNormals(cv_ptr->image.rows,cv_ptr->image.cols,  cv_ptr->image.depth(),K_);
                                ^~~~

This is a rebase of and closes #82