### PR TITLE
[fetch_ros] new meta-package

### DIFF
--- a/fetch_ros/CMakeList.txt
+++ b/fetch_ros/CMakeList.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(fetch_ros)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/fetch_ros/package.xml
+++ b/fetch_ros/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>fetch_ros</name>
+  <version>0.8.0</version>
+  <description>Fetch ROS, packages for working with Fetch and Freight</description>
+  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+
+  <license>BSD</license>
+  <url type="website">https://docs.fetchrobotics.com/</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="wiki">https://wiki.ros.org/fetch_ros</url>
+
+  <author email="amoriarty@fetchrobotics.com">Alex Moriarty</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>fetch_calibration</exec_depend>
+  <exec_depend>fetch_depth_layer</exec_depend>
+  <exec_depend>fetch_description</exec_depend>
+  <exec_depend>fetch_ikfast_plugin</exec_depend>
+  <exec_depend>fetch_maps</exec_depend>
+  <exec_depend>fetch_moveit_config</exec_depend>
+  <exec_depend>fetch_navigation</exec_depend>
+  <exec_depend>fetch_teleop</exec_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+</package>


### PR DESCRIPTION
A meta-package makes installing things easier and they're used with
wiki.ros.org and index.ros.org to automatically group and link things.

See related PR: https://github.com/fetchrobotics/fetch_gazebo/pull/52