### PR TITLE
catkin_make only supports cmake 2.8.3 for meta-pkg

### DIFF
--- a/fetch_ros/CMakeLists.txt
+++ b/fetch_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.3)
 project(fetch_ros)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
See: fetchrobotics/fetch_gazebo#69 and fetchrobotics/fetch_gazebo#70