### PR TITLE
[moveit_config] allow moveit octomap params to be overridden

### DIFF
--- a/fetch_moveit_config/launch/fetch_moveit_sensor_manager.launch.xml
+++ b/fetch_moveit_config/launch/fetch_moveit_sensor_manager.launch.xml
@@ -1,11 +1,11 @@
 <launch>
 
-  <!-- Set the file describing which sensor(s) to use to build the octomap  -->
-  <arg name="moveit_octomap_sensor_params_file" default="$(find fetch_moveit_config)/config/sensors.yaml" />
-
   <!-- Params for the octomap monitor -->
   <param name="octomap_frame" type="string" value="base_link" />
   <param name="octomap_resolution" type="double" value="0.05" />
+
+  <!-- Set the file describing which sensor(s) to use to build the octomap  -->
+  <arg name="moveit_octomap_sensor_params_file" default="$(find fetch_moveit_config)/config/sensors.yaml" />
 
   <!-- sensors used to update the map -->
   <rosparam command="load" file="$(arg moveit_octomap_sensor_params_file)" />

--- a/fetch_moveit_config/launch/move_group.launch
+++ b/fetch_moveit_config/launch/move_group.launch
@@ -16,6 +16,7 @@
   <!-- move_group settings -->
   <arg name="allow_trajectory_execution" default="true"/>
   <arg name="allow_active_sensing" default="false"/>
+  <arg name="moveit_octomap_sensor_params_file" default="$(find fetch_moveit_config)/config/sensors.yaml" />
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />

--- a/fetch_moveit_config/launch/move_group.launch
+++ b/fetch_moveit_config/launch/move_group.launch
@@ -38,6 +38,7 @@
   <rosparam command="delete" param="move_group/sensors" />
   <include ns="move_group" file="$(find fetch_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_active_sensing)">
     <arg name="moveit_sensor_manager" value="fetch" />
+    <arg name="moveit_octomap_sensor_params_file" value="$(arg moveit_octomap_sensor_params_file)"/>
   </include>
 
   <!-- Start the actual move_group node/action server -->

--- a/fetch_moveit_config/launch/sensor_manager.launch.xml
+++ b/fetch_moveit_config/launch/sensor_manager.launch.xml
@@ -1,7 +1,12 @@
 <launch>
 
+  <!-- Set the file describing which sensor(s) to use to build the octomap  -->
+  <arg name="moveit_octomap_sensor_params_file" default="$(find fetch_moveit_config)/config/sensors.yaml" />
+
   <!-- Load the robot specific sensor manager; this sets the moveit_sensor_manager ROS parameter -->
   <arg name="moveit_sensor_manager" default="fetch" />
-  <include file="$(find fetch_moveit_config)/launch/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
+  <include file="$(find fetch_moveit_config)/launch/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml">
+    <arg name="moveit_octomap_sensor_params_file" value="$(arg moveit_octomap_sensor_params_file)"/>
+  </include>
   
 </launch>


### PR DESCRIPTION
Currently there is no way to change `octomap_resolution` without modifying the `fetch_moveit_config` package in `launch/fetch_moveit_sensor_manager.launch.xml`.

So I refered `moveit_pr2` package and changed 3 files.

- https://github.com/ros-planning/moveit_pr2/blob/kinetic-devel/pr2_moveit_config/launch/move_group.launch#L32
- https://github.com/ros-planning/moveit_pr2/blob/kinetic-devel/pr2_moveit_config/launch/sensor_manager.launch.xml
- https://github.com/ros-planning/moveit_pr2/blob/kinetic-devel/pr2_moveit_config/launch/pr2_moveit_sensor_manager.launch.xml

So now you can use `roslaunch fetch_moveit_config move_group.launch allow_active_sensing:=true moveit_octomap_sensor_params_file:=octomap.yaml`

A sample `octomap.yaml` can be

```yaml
octomap_resolution: 0.02
sensors:
  - sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
    point_cloud_topic: /head_camera/depth_downsample/points
    max_range: 1.5
    point_subsample: 1
    padding_offset: 0.05
    padding_scale: 1.0
```