### PR TITLE
Lower the version of package format

### DIFF
--- a/fetch_ros/package.xml
+++ b/fetch_ros/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="3">
+<package format="2">
   <name>fetch_ros</name>
   <version>0.7.15</version>
   <description>Fetch ROS, packages for working with Fetch and Freight</description>


### PR DESCRIPTION
In our Fetch robot PC (indigo), we cannot build `fetch_calibration` with `fetch_ros` of version `0.7.15`.
This is because `<package format="3">` is not compatible with `python-catkin-pkg` of `0.3.9`.
`0.3.9` is the newest `python-catkin-pkg` version which our Fetch robot can install.

```
$ dpkg -l python-catkin-pkg
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                          Version                     Architecture                Description
+++-=============================================-===========================-===========================-===============================================================================================
ii  python-catkin-pkg                             0.3.9-100                   all                         catkin package library
```

In this PR, we change the version of `<package format>` in `package.xml` in `fetch_ros` (version 3 -> 2).


CC. @sktometometo