### PR TITLE
License: CC BY-NC-SA 4.0 (Remove ND)

### DIFF
--- a/fetch_description/package.xml
+++ b/fetch_description/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
-  <license>CreativeCommons-Attribution-NonCommercial-NoDerivatives-4.0</license>
+  <license>CreativeCommons-Attribution-NonCommercial-ShareAlike-4.0-International</license>
   <url type="wiki">http://ros.org/wiki/fetch_description</url>
   <url type="website">http://docs.fetchrobotics.com/robot_hardware.html</url>
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>


### PR DESCRIPTION
This addresses https://github.com/fetchrobotics/fetch_ros/issues/93

It still does not address all points raised, but we believe this is
better than CC-BY-NC-ND as it allows derivatives to be shared.