### PR TITLE
updates maintainers

### DIFF
--- a/fetch_calibration/package.xml
+++ b/fetch_calibration/package.xml
@@ -7,8 +7,12 @@
   </description>
 
   <author>Michael Ferguson</author>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>Apache2</license>
   <url type="wiki">http://ros.org/wiki/fetch_calibration</url>

--- a/fetch_depth_layer/package.xml
+++ b/fetch_depth_layer/package.xml
@@ -5,8 +5,12 @@
   <description>The fetch_depth_layer package</description>
 
   <author>Michael Ferguson</author>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>BSD</license>
   <url type="wiki">http://ros.org/wiki/fetch_depth_layer</url>

--- a/fetch_description/package.xml
+++ b/fetch_description/package.xml
@@ -8,8 +8,12 @@
 
   <author>Michael Ferguson</author>
   <author>Melonee Wise</author>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>CreativeCommons-Attribution-NonCommercial-ShareAlike-4.0-International</license>
   <url type="wiki">http://ros.org/wiki/fetch_description</url>

--- a/fetch_ikfast_plugin/package.xml
+++ b/fetch_ikfast_plugin/package.xml
@@ -6,8 +6,12 @@
     Kinematics plugin for Fetch robot, generated through IKFast
   </description>
   <author>Michael Ferguson</author>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
   <license>Apache2</license>
   <url type="wiki">http://ros.org/wiki/fetch_ikfast_plugin</url>
   <url type="website">http://docs.fetchrobotics.com/manipulation.html</url>

--- a/fetch_maps/package.xml
+++ b/fetch_maps/package.xml
@@ -7,8 +7,12 @@
   <author>Michael Ferguson</author>
   <author>Michael Gregg</author>
   <author>Aaron Blasdel</author>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>BSD</license>
   <url type="wiki">http://ros.org/wiki/fetch_maps</url>

--- a/fetch_moveit_config/package.xml
+++ b/fetch_moveit_config/package.xml
@@ -8,8 +8,11 @@
   </description>
   <author email="assistant@moveit.ros.org">MoveIt Setup Assistant</author>
 
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>BSD</license>
   <url type="wiki">http://ros.org/wiki/fetch_moveit_config</url>

--- a/fetch_navigation/package.xml
+++ b/fetch_navigation/package.xml
@@ -5,8 +5,12 @@
   <description>Configuration and launch files for running ROS navigation on Fetch.</description>
 
   <author>Michael Ferguson</author>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>BSD</license>
   <url type="wiki">http://ros.org/wiki/fetch_navigation</url>

--- a/fetch_ros/package.xml
+++ b/fetch_ros/package.xml
@@ -4,7 +4,11 @@
   <name>fetch_ros</name>
   <version>0.8.2</version>
   <description>Fetch ROS, packages for working with Fetch and Freight</description>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>BSD</license>
   <url type="website">https://docs.fetchrobotics.com/</url>
@@ -12,7 +16,7 @@
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
   <url type="wiki">https://wiki.ros.org/fetch_ros</url>
 
-  <author email="amoriarty@fetchrobotics.com">Alex Moriarty</author>
+  <author>Alex Moriarty</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/fetch_teleop/package.xml
+++ b/fetch_teleop/package.xml
@@ -7,8 +7,12 @@
   </description>
 
   <author>Michael Ferguson</author>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>BSD</license>
   <url type="wiki">http://ros.org/wiki/fetch_teleop</url>


### PR DESCRIPTION
I've done my best to assign appropriate maintainers.

Listed multiple individual maintainers and also included the internal
mailing list to ensure the load is distributed in the event of build
failures.

Related to:

1. fetchrobotics/fetch_msgs#16
2. fetchrobotics/fetch_robots#57
3. fetchrobotics/fetch_gazebo#97
4. fetchrobotics/fetch_demos#3
5. fetchrobotics/fetch_tools#15
6. fetchrobotics/fetch_open_auto_dock#3
7. fetchrobotics/power_msgs#11
8. fetchrobotics/robot_controllers#41

For the new maintainers- worth following the 9 repos which the research customers depend on, it's easy to loose track when they report issues.

I've given @erelson documentation (I can't link to it as I've lost access to the private repo.) which explains the release process, and gave @narora1 a tutorial a while ago. I can be reached on whatsapp or username at bostondynamics.com email address (same format at fetch) if needed.