### PR TITLE
Add ground collision

### DIFF
--- a/fetch_teleop/scripts/tuck_arm.py
+++ b/fetch_teleop/scripts/tuck_arm.py
@@ -80,7 +80,7 @@ class TuckThread(Thread):
         # Padding does not work (especially for self collisions)
         # So we are adding a box above the base of the robot
         scene = PlanningSceneInterface("base_link")
-        scene.addBox("keepout", 0.2, 0.5, 0.05, 0.15, 0.0, 0.375)
+        scene.addBox("keepout", 0.3, 0.5, 0.05, 0.12, 0.0, 0.375)
         scene.addBox("ground", 1.5, 1.5, 0.05, 0.5, 0.0, 0.0)
 
         joints = ["torso_lift_joint", "shoulder_pan_joint", "shoulder_lift_joint", "upperarm_roll_joint",

--- a/fetch_teleop/scripts/tuck_arm.py
+++ b/fetch_teleop/scripts/tuck_arm.py
@@ -81,6 +81,7 @@ class TuckThread(Thread):
         # So we are adding a box above the base of the robot
         scene = PlanningSceneInterface("base_link")
         scene.addBox("keepout", 0.2, 0.5, 0.05, 0.15, 0.0, 0.375)
+        scene.addBox("ground", 1.5, 1.5, 0.05, 0.5, 0.0, 0.0)
 
         joints = ["torso_lift_joint", "shoulder_pan_joint", "shoulder_lift_joint", "upperarm_roll_joint",
                   "elbow_flex_joint", "forearm_roll_joint", "wrist_flex_joint", "wrist_roll_joint"]
@@ -92,6 +93,7 @@ class TuckThread(Thread):
                                                      max_velocity_scaling_factor=0.5)
             if result and result.error_code.val == MoveItErrorCodes.SUCCESS:
                 scene.removeCollisionObject("keepout")
+                scene.removeCollisionObject("ground")
                 if move_thread:
                     move_thread.stop()
 


### PR DESCRIPTION
Add `ground` collision object for tuck_arm.py to avoid Fetch arm crashing into the ground.
It seldomly happens in my our lab.
I also make `keepout` object a bit larger

![fetch_tuckarm_moveit](https://user-images.githubusercontent.com/9300063/68547260-ba58c380-0422-11ea-87cf-6daed0cef9c1.gif)
