### PR TITLE
add topic name args to navigation launch files

### DIFF
--- a/fetch_calibration/CHANGELOG.rst
+++ b/fetch_calibration/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package fetch_calibration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.15 (2019-03-26)
+-------------------
 * [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
 * [Fetch Calibration] fix syntax error (back-port `#96 <https://github.com/fetchrobotics/fetch_ros/issues/96>`_)(`#97 <https://github.com/fetchrobotics/fetch_ros/issues/97>`_)
 * Contributors: Alexander Moriarty

--- a/fetch_calibration/CHANGELOG.rst
+++ b/fetch_calibration/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package fetch_calibration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
+* [Fetch Calibration] fix syntax error (back-port `#96 <https://github.com/fetchrobotics/fetch_ros/issues/96>`_)(`#97 <https://github.com/fetchrobotics/fetch_ros/issues/97>`_)
+* Contributors: Alexander Moriarty
+
 0.7.14 (2018-07-10)
 -------------------
 * updates ownership

--- a/fetch_calibration/launch/capture_manual.launch
+++ b/fetch_calibration/launch/capture_manual.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <rosparam command="delete" param="robot_calibration" >
+  <rosparam command="delete" param="robot_calibration" />
   <node pkg="robot_calibration" type="calibrate" name="robot_calibration"
         args="--manual"
         output="screen" required="true">

--- a/fetch_calibration/package.xml
+++ b/fetch_calibration/package.xml
@@ -10,7 +10,10 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>Apache2</license>
-  <url>http://ros.org/wiki/fetch_calibration</url>
+  <url type="wiki">http://ros.org/wiki/fetch_calibration</url>
+  <url type="website">http://docs.fetchrobotics.com/calibration.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
   
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/fetch_calibration/package.xml
+++ b/fetch_calibration/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>fetch_calibration</name>
-  <version>0.7.14</version>
+  <version>0.7.15</version>
   <description>
     Launch and configuration files for calibrating Fetch using the 'robot_calibration' package.
   </description>

--- a/fetch_calibration/scripts/calibrate_robot
+++ b/fetch_calibration/scripts/calibrate_robot
@@ -171,6 +171,8 @@ if __name__ == "__main__":
     parser.add_argument("--restore", help="Restore the previous calibration", action="store_true")
     parser.add_argument("--date", help="Get the timestamp of the current calibration", action="store_true")
     parser.add_argument("--directory", help="Directory to load calibration from or backup to", default="/tmp")
+    parser.add_argument("--velocity-factor", help="Velocity scaling factor for fetch calibration. Max/default: 1.0",
+                        type=float, default="1.0")
     args = parser.parse_args()
 
     restart = False
@@ -208,7 +210,8 @@ if __name__ == "__main__":
         except:
             print("\nCould not find robot_calibration package, is your ROS path correct?")
             exit(-1)
-        if subprocess.call(["roslaunch", "fetch_calibration", "capture.launch"]) != 0:
+        if subprocess.call(["roslaunch", "fetch_calibration", "capture.launch",
+                            "velocity_factor:={}".format(min(1.0, args.velocity_factor))]) != 0:
             print("Failed to run calibrate")
             exit(-1)
 

--- a/fetch_depth_layer/CHANGELOG.rst
+++ b/fetch_depth_layer/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package fetch_depth_layer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.15 (2019-03-26)
+-------------------
 * [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
 * Contributors: Alexander Moriarty
 

--- a/fetch_depth_layer/CHANGELOG.rst
+++ b/fetch_depth_layer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package fetch_depth_layer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
+* Contributors: Alexander Moriarty
+
 0.7.14 (2018-07-10)
 -------------------
 * updates ownership

--- a/fetch_depth_layer/package.xml
+++ b/fetch_depth_layer/package.xml
@@ -9,6 +9,10 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
+  <url type="wiki">http://ros.org/wiki/fetch_depth_layer</url>
+  <url type="website">http://docs.fetchrobotics.com/perception.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   

--- a/fetch_depth_layer/package.xml
+++ b/fetch_depth_layer/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>fetch_depth_layer</name>
-  <version>0.7.14</version>
+  <version>0.7.15</version>
   <description>The fetch_depth_layer package</description>
 
   <author>Michael Ferguson</author>

--- a/fetch_description/CHANGELOG.rst
+++ b/fetch_description/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package fetch_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.15 (2019-03-26)
+-------------------
 * [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
 * Contributors: Alexander Moriarty
 

--- a/fetch_description/CHANGELOG.rst
+++ b/fetch_description/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package fetch_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
+* Contributors: Alexander Moriarty
+
 0.7.14 (2018-07-10)
 -------------------
 * updates ownership

--- a/fetch_description/package.xml
+++ b/fetch_description/package.xml
@@ -11,6 +11,11 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>CreativeCommons-Attribution-NonCommercial-NoDerivatives-4.0</license>
+  <url type="wiki">http://ros.org/wiki/fetch_description</url>
+  <url type="website">http://docs.fetchrobotics.com/robot_hardware.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
+
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>

--- a/fetch_description/package.xml
+++ b/fetch_description/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>fetch_description</name>
-  <version>0.7.14</version>
+  <version>0.7.15</version>
   <description>
     URDF for Fetch Robot.
   </description>

--- a/fetch_ikfast_plugin/CHANGELOG.rst
+++ b/fetch_ikfast_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package fetch_ikfast_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
+* Contributors: Alexander Moriarty
+
 0.7.14 (2018-07-10)
 -------------------
 * updates ownership

--- a/fetch_ikfast_plugin/CHANGELOG.rst
+++ b/fetch_ikfast_plugin/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package fetch_ikfast_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.15 (2019-03-26)
+-------------------
 * [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
 * Contributors: Alexander Moriarty
 

--- a/fetch_ikfast_plugin/package.xml
+++ b/fetch_ikfast_plugin/package.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='ASCII'?>
 <package>
   <name>fetch_ikfast_plugin</name>
-  <version>0.7.14</version>
+  <version>0.7.15</version>
   <description>
     Kinematics plugin for Fetch robot, generated through IKFast
   </description>

--- a/fetch_ikfast_plugin/package.xml
+++ b/fetch_ikfast_plugin/package.xml
@@ -11,6 +11,10 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>Apache2</license>
+  <url type="wiki">http://ros.org/wiki/fetch_ikfast_plugin</url>
+  <url type="website">http://docs.fetchrobotics.com/manipulation.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/fetch_maps/CHANGELOG.rst
+++ b/fetch_maps/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package fetch_maps
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.15 (2019-03-26)
+-------------------
 * [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
 * Contributors: Alexander Moriarty
 

--- a/fetch_maps/CHANGELOG.rst
+++ b/fetch_maps/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package fetch_maps
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
+* Contributors: Alexander Moriarty
+
 0.7.14 (2018-07-10)
 -------------------
 * updates ownership

--- a/fetch_maps/package.xml
+++ b/fetch_maps/package.xml
@@ -5,13 +5,16 @@
   <description>The fetch_maps package</description>
 
   <author>Michael Ferguson</author>
+  <author>Michael Gregg</author>
+  <author>Aaron Blasdel</author>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
-  <author>Michael Gregg</author>
-  <author>Michael Ferguson</author>
-  <author>Aaron Blasdel</author>
   <license>BSD</license>
+  <url type="wiki">http://ros.org/wiki/fetch_maps</url>
+  <url type="website">http://docs.fetchrobotics.com/navigation.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 </package>

--- a/fetch_maps/package.xml
+++ b/fetch_maps/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>fetch_maps</name>
-  <version>0.7.14</version>
+  <version>0.7.15</version>
   <description>The fetch_maps package</description>
 
   <author>Michael Ferguson</author>

--- a/fetch_moveit_config/CHANGELOG.rst
+++ b/fetch_moveit_config/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package fetch_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
+* Contributors: Alexander Moriarty
+
 0.7.14 (2018-07-10)
 -------------------
 * updates ownership

--- a/fetch_moveit_config/CHANGELOG.rst
+++ b/fetch_moveit_config/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package fetch_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.15 (2019-03-26)
+-------------------
 * [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
 * Contributors: Alexander Moriarty
 

--- a/fetch_moveit_config/package.xml
+++ b/fetch_moveit_config/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>fetch_moveit_config</name>
-  <version>0.7.14</version>
+  <version>0.7.15</version>
   <description>
      An automatically generated package with all the configuration and launch files for using the fetch_urdf with the MoveIt Motion Planning Framework
   </description>

--- a/fetch_moveit_config/package.xml
+++ b/fetch_moveit_config/package.xml
@@ -11,6 +11,7 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
+  <url>http://ros.org/wiki/fetch_moveit_config</url>
 
   <url type="website">http://moveit.ros.org/</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit_setup_assistant/issues</url>

--- a/fetch_navigation/CHANGELOG.rst
+++ b/fetch_navigation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package fetch_navigation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
+* Contributors: Alexander Moriarty
+
 0.7.14 (2018-07-10)
 -------------------
 * updates ownership

--- a/fetch_navigation/CHANGELOG.rst
+++ b/fetch_navigation/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package fetch_navigation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.15 (2019-03-26)
+-------------------
 * [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
 * Contributors: Alexander Moriarty
 

--- a/fetch_navigation/launch/fetch_nav.launch
+++ b/fetch_navigation/launch/fetch_nav.launch
@@ -38,8 +38,7 @@
   <include file="$(arg move_base_include)" >
     <arg name="name" value="fetch" />
     <arg if="$(arg use_keepout)" name="map_topic" value="map_keepout" />
-
-    <arg name="map_topic" value="$(arg map_topic)" />
+    <arg unless="$(arg use_keepout)" name="map_topic" value="$(arg map_topic)" />
     <arg name="cmd_vel_topic" value="$(arg cmd_vel_topic)" />
     <arg name="odom_topic" value="$(arg odom_topic)" />
   </include>

--- a/fetch_navigation/launch/fetch_nav.launch
+++ b/fetch_navigation/launch/fetch_nav.launch
@@ -11,6 +11,12 @@
   <arg name="move_base_include" default="$(find fetch_navigation)/launch/include/move_base.launch.xml" />
   <arg name="amcl_include" default="$(find fetch_navigation)/launch/include/amcl.launch.xml" />
 
+  <!-- set topics -->
+  <arg name="scan_topic"     default="base_scan" />
+  <arg name="map_topic" default="map" />
+  <arg name="cmd_vel_topic" default="cmd_vel" />
+  <arg name="odom_topic" default="odom" />
+
   <!-- serve up a map -->
   <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
 
@@ -23,12 +29,19 @@
   </group>
 
   <!-- localize the robot -->
-  <include file="$(arg amcl_include)" />
+  <include file="$(arg amcl_include)" >
+    <arg name="scan_topic" value="$(arg scan_topic)" />
+    <arg name="map_topic" value="$(arg map_topic)" />
+  </include>
 
   <!-- move the robot -->
   <include file="$(arg move_base_include)" >
     <arg name="name" value="fetch" />
     <arg if="$(arg use_keepout)" name="map_topic" value="map_keepout" />
+
+    <arg name="map_topic" value="$(arg map_topic)" />
+    <arg name="cmd_vel_topic" value="$(arg cmd_vel_topic)" />
+    <arg name="odom_topic" value="$(arg odom_topic)" />
   </include>
 
   <!-- tilt the head -->

--- a/fetch_navigation/launch/freight_nav.launch
+++ b/fetch_navigation/launch/freight_nav.launch
@@ -11,6 +11,11 @@
   <arg name="move_base_include" default="$(find fetch_navigation)/launch/include/move_base.launch.xml" />
   <arg name="amcl_include" default="$(find fetch_navigation)/launch/include/amcl.launch.xml" />
 
+  <!-- set topics for move_base -->
+  <arg name="map_topic" default="map" />
+  <arg name="cmd_vel_topic" default="cmd_vel" />
+  <arg name="odom_topic" default="odom" />
+
   <!-- serve up a map -->
   <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
 
@@ -23,12 +28,19 @@
   </group>
 
   <!-- localize the robot -->
-  <include file="$(arg amcl_include)" />
+  <include file="$(arg amcl_include)" >
+    <arg name="scan_topic" value="$(arg scan_topic)" />
+    <arg name="map_topic" value="$(arg map_topic)" />
+  </include>
 
   <!-- move the robot -->
   <include file="$(arg move_base_include)" >
     <arg name="name" value="freight" />
     <arg if="$(arg use_keepout)" name="map_topic" value="map_keepout" />
+
+    <arg name="map_topic" value="$(arg map_topic)" />
+    <arg name="cmd_vel_topic" value="$(arg cmd_vel_topic)" />
+    <arg name="odom_topic" value="$(arg odom_topic)" />
   </include>
 
 </launch>

--- a/fetch_navigation/launch/freight_nav.launch
+++ b/fetch_navigation/launch/freight_nav.launch
@@ -37,8 +37,7 @@
   <include file="$(arg move_base_include)" >
     <arg name="name" value="freight" />
     <arg if="$(arg use_keepout)" name="map_topic" value="map_keepout" />
-
-    <arg name="map_topic" value="$(arg map_topic)" />
+    <arg unless="$(arg use_keepout)" name="map_topic" value="$(arg map_topic)" />
     <arg name="cmd_vel_topic" value="$(arg cmd_vel_topic)" />
     <arg name="odom_topic" value="$(arg odom_topic)" />
   </include>

--- a/fetch_navigation/package.xml
+++ b/fetch_navigation/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>fetch_navigation</name>
-  <version>0.7.14</version>
+  <version>0.7.15</version>
   <description>Configuration and launch files for running ROS navigation on Fetch.</description>
 
   <author>Michael Ferguson</author>

--- a/fetch_navigation/package.xml
+++ b/fetch_navigation/package.xml
@@ -8,7 +8,10 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
-  <author>Michael Ferguson</author>
+  <url type="wiki">http://ros.org/wiki/fetch_navigation</url>
+  <url type="website">http://docs.fetchrobotics.com/navigation.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/fetch_ros/CHANGELOG.rst
+++ b/fetch_ros/CHANGELOG.rst
@@ -1,0 +1,12 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package fetch_ros
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* [fetch_ros] new meta-package (backport `#110 <https://github.com/fetchrobotics/fetch_ros/issues/110>`_) (`#111 <https://github.com/fetchrobotics/fetch_ros/issues/111>`_)
+* Contributors: Alexander Moriarty
+
+0.7.14 (2018-07-10)
+-------------------
+* Meta-package fetch_ros was newly added after 0.7.14

--- a/fetch_ros/CHANGELOG.rst
+++ b/fetch_ros/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package fetch_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.15 (2019-03-26)
+-------------------
 * [fetch_ros] new meta-package (backport `#110 <https://github.com/fetchrobotics/fetch_ros/issues/110>`_) (`#111 <https://github.com/fetchrobotics/fetch_ros/issues/111>`_)
 * Contributors: Alexander Moriarty
 

--- a/fetch_ros/CMakeLists.txt
+++ b/fetch_ros/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(fetch_ros)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/fetch_ros/package.xml
+++ b/fetch_ros/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>fetch_ros</name>
+  <version>0.7.14</version>
+  <description>Fetch ROS, packages for working with Fetch and Freight</description>
+  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+
+  <license>BSD</license>
+  <url type="website">https://docs.fetchrobotics.com/</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="wiki">https://wiki.ros.org/fetch_ros</url>
+
+  <author email="amoriarty@fetchrobotics.com">Alex Moriarty</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>fetch_calibration</exec_depend>
+  <exec_depend>fetch_depth_layer</exec_depend>
+  <exec_depend>fetch_description</exec_depend>
+  <exec_depend>fetch_ikfast_plugin</exec_depend>
+  <exec_depend>fetch_maps</exec_depend>
+  <exec_depend>fetch_moveit_config</exec_depend>
+  <exec_depend>fetch_navigation</exec_depend>
+  <exec_depend>fetch_teleop</exec_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+</package>

--- a/fetch_ros/package.xml
+++ b/fetch_ros/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="3">
+<package format="2">
   <name>fetch_ros</name>
   <version>0.7.15</version>
   <description>Fetch ROS, packages for working with Fetch and Freight</description>

--- a/fetch_ros/package.xml
+++ b/fetch_ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fetch_ros</name>
-  <version>0.7.14</version>
+  <version>0.7.15</version>
   <description>Fetch ROS, packages for working with Fetch and Freight</description>
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 

--- a/fetch_teleop/CHANGELOG.rst
+++ b/fetch_teleop/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package fetch_teleop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.15 (2019-03-26)
+-------------------
 * [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
 * [teleop] Safer arm teleop (`#95 <https://github.com/fetchrobotics/fetch_ros/issues/95>`_) (backport `#92 <https://github.com/fetchrobotics/fetch_ros/issues/92>`_)
   * Require primary dead-man for arm teleop, along with with the angular or linear selector button.

--- a/fetch_teleop/CHANGELOG.rst
+++ b/fetch_teleop/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package fetch_teleop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [Docs] Add URL tags to package for wiki.ros.org (backport) (`#91 <https://github.com/fetchrobotics/fetch_ros/issues/91>`_)
+* [teleop] Safer arm teleop (`#95 <https://github.com/fetchrobotics/fetch_ros/issues/95>`_) (backport `#92 <https://github.com/fetchrobotics/fetch_ros/issues/92>`_)
+  * Require primary dead-man for arm teleop, along with with the angular or linear selector button.
+* Contributors: Alexander Moriarty, Eric Relson
+
 0.7.14 (2018-07-10)
 -------------------
 * updates ownership

--- a/fetch_teleop/package.xml
+++ b/fetch_teleop/package.xml
@@ -10,7 +10,10 @@
   <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
 
   <license>BSD</license>
-  <url>http://ros.org/wiki/fetch_teleop</url>
+  <url type="wiki">http://ros.org/wiki/fetch_teleop</url>
+  <url type="website">http://docs.fetchrobotics.com/teleop.html</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_ros/issues</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_ros</url>
   
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/fetch_teleop/package.xml
+++ b/fetch_teleop/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>fetch_teleop</name>
-  <version>0.7.14</version>
+  <version>0.7.15</version>
   <description>
     Teleoperation for fetch and freight.
   </description>

--- a/fetch_teleop/scripts/tuck_arm.py
+++ b/fetch_teleop/scripts/tuck_arm.py
@@ -80,7 +80,8 @@ class TuckThread(Thread):
         # Padding does not work (especially for self collisions)
         # So we are adding a box above the base of the robot
         scene = PlanningSceneInterface("base_link")
-        scene.addBox("keepout", 0.2, 0.5, 0.05, 0.15, 0.0, 0.375)
+        scene.addBox("keepout", 0.3, 0.5, 0.05, 0.12, 0.0, 0.375)
+        scene.addBox("ground", 1.5, 1.5, 0.05, 0.5, 0.0, 0.0)
 
         joints = ["torso_lift_joint", "shoulder_pan_joint", "shoulder_lift_joint", "upperarm_roll_joint",
                   "elbow_flex_joint", "forearm_roll_joint", "wrist_flex_joint", "wrist_roll_joint"]
@@ -92,6 +93,7 @@ class TuckThread(Thread):
                                                      max_velocity_scaling_factor=0.5)
             if result and result.error_code.val == MoveItErrorCodes.SUCCESS:
                 scene.removeCollisionObject("keepout")
+                scene.removeCollisionObject("ground")
                 if move_thread:
                     move_thread.stop()
 

--- a/fetch_teleop/src/joystick_teleop.cpp
+++ b/fetch_teleop/src/joystick_teleop.cpp
@@ -720,32 +720,57 @@ public:
   void init(ros::NodeHandle& nh)
   {
     bool is_fetch;
+    bool use_torso;
+    bool use_gripper;
+    bool use_head;
+    bool use_arm;
+    bool use_base;
     nh.param("is_fetch", is_fetch, true);
+    nh.param("use_torso", use_torso, true);
+    nh.param("use_gripper", use_gripper, true);
+    nh.param("use_head", use_head, true);
+    nh.param("use_arm", use_arm, true);
+    nh.param("use_base", use_base, true);
 
     // TODO: load these from YAML
 
     TeleopComponentPtr c;
     if (is_fetch)
     {
-      // Torso does not override
-      c.reset(new FollowTeleop("torso", nh));
-      components_.push_back(c);
+      if (use_torso)
+      {
+        // Torso does not override
+        c.reset(new FollowTeleop("torso", nh));
+        components_.push_back(c);
+      }
 
-      // Gripper does not override
-      c.reset(new GripperTeleop("gripper", nh));
-      components_.push_back(c);
+      if (use_gripper)
+      {
+        // Gripper does not override
+        c.reset(new GripperTeleop("gripper", nh));
+        components_.push_back(c);
+      }
 
-      // Head overrides base
-      c.reset(new HeadTeleop("head", nh));
-      components_.push_back(c);
+      if (use_head)
+      {
+        // Head overrides base
+        c.reset(new HeadTeleop("head", nh));
+        components_.push_back(c);
+      }
 
-      c.reset(new ArmTeleop("arm", nh));
-      components_.push_back(c);
+      if (use_arm)
+      {
+        c.reset(new ArmTeleop("arm", nh));
+        components_.push_back(c);
+      }
     }
 
-    // BaseTeleop goes last
-    c.reset(new BaseTeleop("base", nh));
-    components_.push_back(c);
+    if (use_base)
+    {
+      // BaseTeleop goes last
+      c.reset(new BaseTeleop("base", nh));
+      components_.push_back(c);
+    }
 
     state_msg_.reset(new sensor_msgs::JointState());
     joy_sub_ = nh.subscribe("/joy", 1, &Teleop::joyCallback, this);

--- a/fetch_teleop/src/joystick_teleop.cpp
+++ b/fetch_teleop/src/joystick_teleop.cpp
@@ -580,6 +580,7 @@ public:
     pnh.param("axis_pitch", axis_pitch_, 3);
     pnh.param("axis_yaw", axis_yaw_, 0);
 
+    pnh.param("button_deadman", deadman_, 10);
     pnh.param("button_arm_linear", button_linear_, 9);
     pnh.param("button_arm_angular", button_angular_, 11);
 
@@ -604,10 +605,11 @@ public:
   virtual bool update(const sensor_msgs::Joy::ConstPtr& joy,
                       const sensor_msgs::JointState::ConstPtr& state)
   {
+    bool deadman_pressed = joy->buttons[deadman_];
     bool button_linear_pressed = joy->buttons[button_linear_];
     bool button_angular_pressed = joy->buttons[button_angular_];
 
-    if (!(button_linear_pressed || button_angular_pressed) &&
+    if ((!(button_linear_pressed || button_angular_pressed) || !deadman_pressed) &&
         (ros::Time::now() - last_update_ > ros::Duration(0.5)))
     {
       stop();
@@ -691,6 +693,7 @@ public:
 private:
 
   // Buttons from params
+  int deadman_;
   int axis_x_, axis_y_, axis_z_, axis_roll_, axis_pitch_, axis_yaw_;
   int button_linear_, button_angular_;
 


### PR DESCRIPTION
I have added topic name arguments to navigation launch files so that navigation topics can be remapped to other topics. ( like remapping /odom to /odom_visual )