### PR TITLE
[fetch_navigation][melodic] add use_map_topic arg in fetch_nav.launch

### DIFF
--- a/fetch_navigation/launch/fetch_nav.launch
+++ b/fetch_navigation/launch/fetch_nav.launch
@@ -6,6 +6,7 @@
   <arg name="map_file" default="$(find fetch_maps)/maps/3_1_16_localization.yaml" />
   <arg name="map_keepout_file" default="$(find fetch_maps)/maps/3_1_16_keepout.yaml" />
   <arg name="use_keepout" default="false" />
+  <arg name="use_map_topic"  default="false" />
 
   <!-- Navigation parameter files -->
   <arg name="move_base_include" default="$(find fetch_navigation)/launch/include/move_base.launch.xml" />
@@ -32,6 +33,7 @@
   <include file="$(arg amcl_include)" >
     <arg name="scan_topic" value="$(arg scan_topic)" />
     <arg name="map_topic" value="$(arg map_topic)" />
+    <arg name="use_map_topic" value="$(arg use_map_topic)" />
   </include>
 
   <!-- move the robot -->


### PR DESCRIPTION
melodic version of #144 

add `use_map_topic` arg for `fetch_nav.launch`
we use this argument for `amcl` with `multi_map_server`.
we don't have Fetch robot with melodic, so we haven't tested on a real robot.

cc. @708yamaguchi 