### PR TITLE
Fix tuck arm moveit check [OPEN-48]

### DIFF
--- a/fetch_teleop/scripts/tuck_arm.py
+++ b/fetch_teleop/scripts/tuck_arm.py
@@ -53,7 +53,10 @@ class MoveItThread(Thread):
         self.process.wait()
 
 def is_moveit_running():
-    output = subprocess.check_output(["rosnode", "info", "move_group"], stderr=subprocess.STDOUT)
+   try:
+        output = subprocess.check_output(["rosnode", "info", "move_group"], stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        output = e.output
     if output.find("unknown node") >= 0:
         return False
     if output.find("Communication with node") >= 0:
@@ -72,6 +75,8 @@ class TuckThread(Thread):
         if not is_moveit_running():
             rospy.loginfo("starting moveit")
             move_thread = MoveItThread()
+        else:
+            rospy.loginfo("moveit already started")
 
         rospy.loginfo("Waiting for MoveIt...")
         self.client = MoveGroupInterface("arm_with_torso", "base_link")

--- a/fetch_teleop/scripts/tuck_arm.py
+++ b/fetch_teleop/scripts/tuck_arm.py
@@ -53,7 +53,7 @@ class MoveItThread(Thread):
         self.process.wait()
 
 def is_moveit_running():
-   try:
+    try:
         output = subprocess.check_output(["rosnode", "info", "move_group"], stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         output = e.output


### PR DESCRIPTION
`rosnode info` exits with a non-zero return code when a connection cannot be established with a node's URI. In the case of arm tuck, it happens with the moveit node "move_group" any run after the first and is problematic because the node expects to be killed and respawned on success. Since this command is run via `subprocess.check_output` , a `subprocess.CalledProcessError` exception is raised, killing the process.
https://github.com/ros/ros_comm/blob/melodic-devel/tools/rosnode/src/rosnode/__init__.py#L565

See also:
https://github.com/fetchrobotics/fetch_robots/pull/59

Please review @erelson 