### PR TITLE
Add srdf file path argument to move_group.launch

### DIFF
--- a/fetch_moveit_config/launch/move_group.launch
+++ b/fetch_moveit_config/launch/move_group.launch
@@ -1,6 +1,9 @@
 <launch>
 
-  <include file="$(find fetch_moveit_config)/launch/planning_context.launch" />
+  <arg name="srdf" default="$(find fetch_moveit_config)/config/fetch.srdf" />
+  <include file="$(find fetch_moveit_config)/launch/planning_context.launch" >
+    <arg name="srdf" value="$(arg srdf)" />
+  </include>
 
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />

--- a/fetch_moveit_config/launch/planning_context.launch
+++ b/fetch_moveit_config/launch/planning_context.launch
@@ -6,12 +6,15 @@
   <!-- The name of the parameter under which the URDF is loaded -->
   <arg name="robot_description" default="robot_description"/>
 
+  <!-- The path to srdf file -->
+  <arg name="srdf" default="$(find fetch_moveit_config)/config/fetch.srdf" />
+
   <!-- Load universal robot description format (URDF) -->
   <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fetch_description)/robots/fetch.urdf"/>
 
   <!-- The semantic description that corresponds to the URDF -->
-  <param name="$(arg robot_description)_semantic" textfile="$(find fetch_moveit_config)/config/fetch.srdf" />
-  
+  <param name="$(arg robot_description)_semantic" textfile="$(arg srdf)" />
+
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
     <rosparam command="load" file="$(find fetch_moveit_config)/config/joint_limits.yaml"/>

--- a/fetch_moveit_config/launch/planning_context.launch
+++ b/fetch_moveit_config/launch/planning_context.launch
@@ -13,7 +13,7 @@
   <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fetch_description)/robots/fetch.urdf"/>
 
   <!-- The semantic description that corresponds to the URDF -->
-  <param name="$(arg robot_description)_semantic" textfile="$(arg srdf)" />
+  <param name="$(arg robot_description)_semantic" command="$(find xacro)/xacro --inorder $(arg srdf)" />
 
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">


### PR DESCRIPTION
I add srdf path argument to `move_group.launch` and `planning_context.launch`.
I think this feature is needed when we want to use different srdf on gazebo and on the real machine.
Related to https://github.com/fetchrobotics/fetch_gazebo/pull/109