### PR TITLE
Add link to rt for compilation in RoboStack

### DIFF
--- a/fetch_teleop/CMakeLists.txt
+++ b/fetch_teleop/CMakeLists.txt
@@ -29,6 +29,10 @@ target_link_libraries(joystick_teleop
   ${catkin_LIBRARIES}
 )
 
+if(UNIX AND NOT APPLE)
+  target_link_libraries(joystick_teleop rt)
+endif()
+
 install(
   TARGETS joystick_teleop
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
While Ubuntu/Debian systems pull in rt automatically, the underlying CentOS under conda, which we use in the RoboStack project (https://github.com/RoboStack/ros-noetic), does not. This fixes this issue.