### PR TITLE
update enforce_joint_model_state_space in config

### DIFF
--- a/fetch_moveit_config/config/ompl_planning.yaml
+++ b/fetch_moveit_config/config/ompl_planning.yaml
@@ -36,6 +36,10 @@ arm:
     - PRMstarkConfigDefault
   projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
   longest_valid_segment_fraction: 0.005
+  # this will enforce JointModelStateSpaceFactory for problem representing see 
+  # https://github.com/ros-planning/moveit/pull/541 for detail
+  # basically this would allow path constraints in moveit_commander to work properly
+  enforce_joint_model_state_space: true
 arm_with_torso:
   planner_configs:
     - SBLkConfigDefault
@@ -51,6 +55,10 @@ arm_with_torso:
     - PRMstarkConfigDefault
   projection_evaluator: joints(torso_lift_joint,shoulder_pan_joint)
   longest_valid_segment_fraction: 0.05
+  # this will enforce JointModelStateSpaceFactory for problem representing see 
+  # https://github.com/ros-planning/moveit/pull/541 for detail
+  # basically this would allow path constraints in moveit_commander to work properly
+  enforce_joint_model_state_space: true
 gripper:
   planner_configs:
     - SBLkConfigDefault

--- a/fetch_moveit_config/config/ompl_planning.yaml
+++ b/fetch_moveit_config/config/ompl_planning.yaml
@@ -36,9 +36,6 @@ arm:
     - PRMstarkConfigDefault
   projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
   longest_valid_segment_fraction: 0.005
-  # this will enforce JointModelStateSpaceFactory for problem representing see 
-  # https://github.com/ros-planning/moveit/pull/541 for detail
-  # basically this would allow path constraints in moveit_commander to work properly
   enforce_joint_model_state_space: true
 arm_with_torso:
   planner_configs:
@@ -55,9 +52,6 @@ arm_with_torso:
     - PRMstarkConfigDefault
   projection_evaluator: joints(torso_lift_joint,shoulder_pan_joint)
   longest_valid_segment_fraction: 0.05
-  # this will enforce JointModelStateSpaceFactory for problem representing see 
-  # https://github.com/ros-planning/moveit/pull/541 for detail
-  # basically this would allow path constraints in moveit_commander to work properly
   enforce_joint_model_state_space: true
 gripper:
   planner_configs:


### PR DESCRIPTION
I've encountered a problem where set_path_constraint in moveit commander with orientation constraint didn't really work (Sometimes it is still going out of the constraint). After a bit of research, I found this workaround in Moveit! See this pose for detail https://github.com/ros-planning/moveit/pull/541. With this changes in the ompl_planner.yaml it will enforce it to choose store info in joint space which will make sure the set_path_constraint interface behaves as desired. See https://www.youtube.com/watch?v=kIy_dX4ovQM&ab_channel=%E6%96%B9%E6%98%93%E9%9D%9E this video for constrain in work.