### PR TITLE
[fetch_moveit_config] fix fetch.srdf to avoid self collision and warnings

### DIFF
--- a/fetch_moveit_config/config/fetch.srdf
+++ b/fetch_moveit_config/config/fetch.srdf
@@ -94,7 +94,7 @@
     <disable_collisions link1="estop_link" link2="head_tilt_link" reason="Never" />
     <disable_collisions link1="estop_link" link2="l_wheel_link" reason="Never" />
     <disable_collisions link1="estop_link" link2="laser_link" reason="Never" />
-    <disable_collisions link1="estop_link" link2="r_gripper_finger_link" reason="Never" />
+    <!-- <disable_collisions link1="estop_link" link2="r_gripper_finger_link" reason="Never" /> -->
     <disable_collisions link1="estop_link" link2="r_wheel_link" reason="Never" />
     <disable_collisions link1="estop_link" link2="shoulder_lift_link" reason="Never" />
     <disable_collisions link1="estop_link" link2="shoulder_pan_link" reason="Never" />

--- a/fetch_moveit_config/config/fetch.srdf
+++ b/fetch_moveit_config/config/fetch.srdf
@@ -48,6 +48,10 @@
     <disable_collisions link1="base_link" link2="shoulder_pan_link" reason="Never" />
     <disable_collisions link1="base_link" link2="torso_fixed_link" reason="Adjacent" />
     <disable_collisions link1="base_link" link2="torso_lift_link" reason="Adjacent" />
+    <disable_collisions link1="base_link" link2="fl_caster_link" reason="Adjacent" />
+    <disable_collisions link1="base_link" link2="fr_caster_link" reason="Adjacent" />
+    <disable_collisions link1="base_link" link2="bl_caster_link" reason="Adjacent" />
+    <disable_collisions link1="base_link" link2="br_caster_link" reason="Adjacent" />
     <!-- <disable_collisions link1="base_link" link2="upperarm_roll_link" reason="Never" /> -->
     <disable_collisions link1="bellows_link" link2="bellows_link2" reason="Default" />
     <disable_collisions link1="bellows_link" link2="elbow_flex_link" reason="Never" />

--- a/fetch_moveit_config/config/fetch.srdf
+++ b/fetch_moveit_config/config/fetch.srdf
@@ -48,7 +48,7 @@
     <disable_collisions link1="base_link" link2="shoulder_pan_link" reason="Never" />
     <disable_collisions link1="base_link" link2="torso_fixed_link" reason="Adjacent" />
     <disable_collisions link1="base_link" link2="torso_lift_link" reason="Adjacent" />
-    <disable_collisions link1="base_link" link2="upperarm_roll_link" reason="Never" />
+    <!-- <disable_collisions link1="base_link" link2="upperarm_roll_link" reason="Never" /> -->
     <disable_collisions link1="bellows_link" link2="bellows_link2" reason="Default" />
     <disable_collisions link1="bellows_link" link2="elbow_flex_link" reason="Never" />
     <disable_collisions link1="bellows_link" link2="estop_link" reason="Never" />


### PR DESCRIPTION
This PR adds possible collision check and ignore warning.

## Add possible collision check
- `base_link` and `upperarm_roll_link` can collide, but ignored in current `melodic-devel`.
  - [check collision between base_link and upperarm_roll_link ](https://github.com/ZebraDevs/fetch_ros/commit/41157e09ae4052466f281cd6c39045d76cbaf8d7)
- `e-stop` and `r_gripper_finger_link` can collide, but ignored in `melodic-devel`
  - [check collision between E-stop and gripper](https://github.com/ZebraDevs/fetch_ros/commit/fd36e4844deb58264dd4fde85e4195be286c6d57)

## Ignore warning
- [disable caster and base_link collision](https://github.com/ZebraDevs/fetch_ros/commit/301580f7df23338a93f46061f2f4b6d113e08933)