### PR TITLE
[fetch_moveit_config] set enforce_joint_model_state_space true

### DIFF
--- a/fetch_moveit_config/config/ompl_planning.yaml
+++ b/fetch_moveit_config/config/ompl_planning.yaml
@@ -36,6 +36,7 @@ arm:
     - PRMstarkConfigDefault
   projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
   longest_valid_segment_fraction: 0.005
+  enforce_joint_model_state_space: true
 arm_with_torso:
   planner_configs:
     - SBLkConfigDefault
@@ -51,6 +52,7 @@ arm_with_torso:
     - PRMstarkConfigDefault
   projection_evaluator: joints(torso_lift_joint,shoulder_pan_joint)
   longest_valid_segment_fraction: 0.05
+  enforce_joint_model_state_space: true
 gripper:
   planner_configs:
     - SBLkConfigDefault


### PR DESCRIPTION
fetch arm collides with base or torso when `path constraints` is given to `MotionPlanRequest`.
This is because Moveit computes in `cartesian model state space` when `path constraints` is given, 
and it causes joint jump near singularity point.
With this joint jump, fetch's arm collides with its base or torso because fetch's arm is quite close to them.

## Good case

https://user-images.githubusercontent.com/9300063/195620089-c3443451-4408-4593-8e54-cae00bc75e2e.mp4

## Bad case

https://user-images.githubusercontent.com/9300063/195620117-91db585f-c6ba-41d0-b555-481615c1a83c.mp4

In this PR, I set `enforce_joint_model_state_space` `true` and enforce to use `joint model state space`.
This change may needs longer planning time but it is safe.

related:
https://github.com/ros-planning/moveit/pull/541
https://github.com/ros-planning/moveit/issues/562
https://github.com/ros-planning/moveit/pull/2273
