### PR TITLE
[fetch_moveit_config] inclease collision check for arm_with_torso

### DIFF
--- a/fetch_moveit_config/config/ompl_planning.yaml
+++ b/fetch_moveit_config/config/ompl_planning.yaml
@@ -50,7 +50,7 @@ arm_with_torso:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(torso_lift_joint,shoulder_pan_joint)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.005
 gripper:
   planner_configs:
     - SBLkConfigDefault


### PR DESCRIPTION
this PR changes `longest_valid_segment_fraction` from `0.05` to `0.005`.
this changes is applied to `arm` group in #122 , but not in `arm_with_torso` group, so I made this PR.